### PR TITLE
1 fast parsing

### DIFF
--- a/GeospatialKit.xcodeproj/project.pbxproj
+++ b/GeospatialKit.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		1EFA49EC1F683AD700125618 /* MultiPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA49EB1F683AD700125618 /* MultiPoint.swift */; };
 		1EFA49EE1F683AE600125618 /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA49ED1F683AE600125618 /* Point.swift */; };
 		9F0CDF4B1ECA558800E630D7 /* LineStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0CDF4A1ECA558800E630D7 /* LineStringTests.swift */; };
+		9F197BC42061C2220002EB5D /* GeoJsonParsingPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F197BC32061C2220002EB5D /* GeoJsonParsingPerformanceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -227,6 +228,7 @@
 		1EFA49EB1F683AD700125618 /* MultiPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiPoint.swift; sourceTree = "<group>"; };
 		1EFA49ED1F683AE600125618 /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
 		9F0CDF4A1ECA558800E630D7 /* LineStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineStringTests.swift; sourceTree = "<group>"; };
+		9F197BC32061C2220002EB5D /* GeoJsonParsingPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoJsonParsingPerformanceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -645,6 +647,7 @@
 		1E528ECA1EC20CDF00A2A9C9 /* GeospatialKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				9F197BC22061C1CD0002EB5D /* Performance */,
 				1E1076FA20409B6000B5AD00 /* Mock */,
 				1E10770320409BE700B5AD00 /* Test */,
 				1E1076F820409B3E00B5AD00 /* Data */,
@@ -690,6 +693,14 @@
 				1E528ECD1EC20CDF00A2A9C9 /* Info.plist */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		9F197BC22061C1CD0002EB5D /* Performance */ = {
+			isa = PBXGroup;
+			children = (
+				9F197BC32061C2220002EB5D /* GeoJsonParsingPerformanceTests.swift */,
+			);
+			path = Performance;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -939,6 +950,7 @@
 				1EB9FEDA1EC5F0D700F4AA29 /* BoundingBoxTests.swift in Sources */,
 				1E8D524A1F62FD4D009BA3DD /* MockGeoJsonBoundingBox.swift in Sources */,
 				1E2EEF2B1ED612B100BA7C8C /* MockData.swift in Sources */,
+				9F197BC42061C2220002EB5D /* GeoJsonParsingPerformanceTests.swift in Sources */,
 				1E8D525D1F6317B3009BA3DD /* MockGeoJsonMultiCoordinatesGeometry.swift in Sources */,
 				1E73FBC91F97DF85001747AD /* MockGeospatial.swift in Sources */,
 				1E0CDEBA1ED71BA10066D74F /* WktParserTests.swift in Sources */,

--- a/GeospatialKit/API/GeoJson/GeoJson.swift
+++ b/GeospatialKit/API/GeoJson/GeoJson.swift
@@ -99,7 +99,7 @@ public protocol GeoJsonProtocol {
     func point(longitude: Double, latitude: Double) -> GeoJsonPoint
 }
 
-public class GeoJson: GeoJsonProtocol {
+public final class GeoJson: GeoJsonProtocol {
     internal let logger: LoggerProtocol
     internal let geodesicCalculator: GeodesicCalculatorProtocol
     

--- a/GeospatialKit/API/GeoJson/Object/Feature.swift
+++ b/GeospatialKit/API/GeoJson/Object/Feature.swift
@@ -15,7 +15,7 @@ extension GeoJson {
         return Feature(logger: logger, geometry: geometry, id: id, properties: properties)
     }
     
-    public class Feature: GeoJsonFeature, Equatable {
+    public final class Feature: GeoJsonFeature, Equatable {
         public let type: GeoJsonObjectType = .feature
         public var geoJson: GeoJsonDictionary {
             var geoJson: GeoJsonDictionary = ["type": type.rawValue, "geometry": geometry?.geoJson ?? NSNull(), "properties": properties ?? NSNull()]

--- a/GeospatialKit/API/GeoJson/Object/FeatureCollection.swift
+++ b/GeospatialKit/API/GeoJson/Object/FeatureCollection.swift
@@ -12,7 +12,7 @@ extension GeoJson {
         return FeatureCollection(logger: logger, features: features)
     }
     
-    public class FeatureCollection: GeoJsonFeatureCollection, Equatable {
+    public final class FeatureCollection: GeoJsonFeatureCollection, Equatable {
         public let type: GeoJsonObjectType = .featureCollection
         public var geoJson: GeoJsonDictionary { return ["type": type.rawValue, "features": features.map { $0.geoJson } ] }
         

--- a/GeospatialKit/API/GeoJson/Object/GeometryCollection.swift
+++ b/GeospatialKit/API/GeoJson/Object/GeometryCollection.swift
@@ -10,7 +10,7 @@ extension GeoJson {
         return GeometryCollection(logger: logger, geometries: geometries)
     }
     
-    public class GeometryCollection: GeoJsonGeometryCollection, Equatable {
+    public final class GeometryCollection: GeoJsonGeometryCollection, Equatable {
         public let type: GeoJsonObjectType = .geometryCollection
         public var geoJson: GeoJsonDictionary { return ["type": type.rawValue, "geometries": objectGeometries?.map { $0.geoJson } ?? [] ] }
         

--- a/GeospatialKit/API/GeoJson/Object/LineString.swift
+++ b/GeospatialKit/API/GeoJson/Object/LineString.swift
@@ -34,10 +34,19 @@ extension GeoJson {
         private let geodesicCalculator: GeodesicCalculatorProtocol
         
         public let points: [GeoJsonPoint]
-        public let boundingBox: GeoJsonBoundingBox
-        public let centroid: GeodesicPoint
         
-        public let length: Double
+        public var boundingBox: GeoJsonBoundingBox {
+            return BoundingBox.best(points.flatMap { $0.boundingBox })!
+        }
+        
+        public var centroid: GeodesicPoint {
+            return geodesicCalculator.centroid(linePoints: points)
+        }
+        
+        public var length: Double {
+            return geodesicCalculator.length(lineSegments: segments)
+        }
+        
         public let segments: [GeoJsonLineSegment]
         
         internal convenience init?(logger: LoggerProtocol, geodesicCalculator: GeodesicCalculatorProtocol, coordinatesJson: [Any]) {
@@ -62,18 +71,12 @@ extension GeoJson {
             self.geodesicCalculator = geodesicCalculator
             
             self.points = points
-            
-            boundingBox = BoundingBox.best(points.flatMap { $0.boundingBox })!
-            
-            centroid = geodesicCalculator.centroid(linePoints: points)
-            
+
             segments = points.enumerated().flatMap { (offset, point) in
                 if points.count == offset + 1 { return nil }
                 
                 return (point, points[offset + 1])
             }
-            
-            length = geodesicCalculator.length(lineSegments: segments)
         }
         
         public func distance(to point: GeodesicPoint, errorDistance: Double) -> Double {

--- a/GeospatialKit/API/GeoJson/Object/LineString.swift
+++ b/GeospatialKit/API/GeoJson/Object/LineString.swift
@@ -15,7 +15,7 @@ extension GeoJson {
         return LineString(logger: logger, geodesicCalculator: geodesicCalculator, points: points)
     }
     
-    public class LineString: GeoJsonLineString, Equatable {
+    public final class LineString: GeoJsonLineString, Equatable {
         public let type: GeoJsonObjectType = .lineString
         public var geoJsonCoordinates: [Any] { return points.map { $0.geoJsonCoordinates } }
         

--- a/GeospatialKit/API/GeoJson/Object/MultiLineString.swift
+++ b/GeospatialKit/API/GeoJson/Object/MultiLineString.swift
@@ -12,7 +12,7 @@ extension GeoJson {
         return MultiLineString(logger: logger, geodesicCalculator: geodesicCalculator, lineStrings: lineStrings)
     }
     
-    public class MultiLineString: GeoJsonMultiLineString, Equatable {
+    public final class MultiLineString: GeoJsonMultiLineString, Equatable {
         public let type: GeoJsonObjectType = .multiLineString
         public var geoJsonCoordinates: [Any] { return lineStrings.map { $0.geoJsonCoordinates } }
         

--- a/GeospatialKit/API/GeoJson/Object/MultiLineString.swift
+++ b/GeospatialKit/API/GeoJson/Object/MultiLineString.swift
@@ -28,12 +28,21 @@ extension GeoJson {
         }
         
         private let logger: LoggerProtocol
+        private let geodesicCalculator: GeodesicCalculatorProtocol
         
         public let lineStrings: [GeoJsonLineString]
         
-        public let points: [GeoJsonPoint]
-        public let boundingBox: GeoJsonBoundingBox
-        public let centroid: GeodesicPoint
+        public var points: [GeoJsonPoint] {
+            return lineStrings.flatMap { $0.points }
+        }
+        
+        public var boundingBox: GeoJsonBoundingBox {
+            return BoundingBox.best(lineStrings.map { $0.boundingBox })!
+        }
+        
+        public var centroid: GeodesicPoint {
+            return geodesicCalculator.centroid(lines: lineStrings)
+        }
         
         internal convenience init?(logger: LoggerProtocol, geodesicCalculator: GeodesicCalculatorProtocol, coordinatesJson: [Any]) {
             guard let lineStringsJson = coordinatesJson as? [[Any]] else { logger.error("A valid MultiLineString must have valid coordinates"); return nil }
@@ -54,15 +63,9 @@ extension GeoJson {
             guard lineStrings.count >= 1 else { logger.error("A valid MultiLineString must have at least one LineString"); return nil }
             
             self.logger = logger
+            self.geodesicCalculator = geodesicCalculator
             
             self.lineStrings = lineStrings
-            
-            boundingBox = BoundingBox.best(lineStrings.map { $0.boundingBox })!
-            
-            let points = lineStrings.flatMap { $0.points }
-            self.points = points
-            
-            centroid = geodesicCalculator.centroid(lines: lineStrings)
         }
         
         public func distance(to point: GeodesicPoint, errorDistance: Double) -> Double { return lineStrings.map { $0.distance(to: point, errorDistance: errorDistance) }.min()! }

--- a/GeospatialKit/API/GeoJson/Object/MultiPoint.swift
+++ b/GeospatialKit/API/GeoJson/Object/MultiPoint.swift
@@ -26,10 +26,17 @@ extension GeoJson {
         }
         
         private let logger: LoggerProtocol
+        private let geodesicCalculator: GeodesicCalculatorProtocol
         
         public let points: [GeoJsonPoint]
-        public let boundingBox: GeoJsonBoundingBox
-        public let centroid: GeodesicPoint
+        
+        public var boundingBox: GeoJsonBoundingBox {
+            return BoundingBox.best(points.flatMap { $0.boundingBox })!
+        }
+        
+        public var centroid: GeodesicPoint {
+            return geodesicCalculator.centroid(points: points)
+        }
         
         internal convenience init?(logger: LoggerProtocol, geodesicCalculator: GeodesicCalculatorProtocol, coordinatesJson: [Any]) {
             guard let pointsJson = coordinatesJson as? [[Any]] else { logger.error("A valid MultiPoint must have valid coordinates"); return nil }
@@ -50,12 +57,9 @@ extension GeoJson {
             guard points.count >= 1 else { logger.error("A valid MultiPoint must have at least one Point"); return nil }
             
             self.logger = logger
+            self.geodesicCalculator = geodesicCalculator
             
             self.points = points
-            
-            boundingBox = BoundingBox.best(points.flatMap { $0.boundingBox })!
-            
-            centroid = geodesicCalculator.centroid(points: points)
         }
         
         public func distance(to point: GeodesicPoint, errorDistance: Double) -> Double {

--- a/GeospatialKit/API/GeoJson/Object/MultiPoint.swift
+++ b/GeospatialKit/API/GeoJson/Object/MultiPoint.swift
@@ -10,7 +10,7 @@ extension GeoJson {
         return MultiPoint(logger: logger, geodesicCalculator: geodesicCalculator, points: points)
     }
     
-    public class MultiPoint: GeoJsonMultiPoint, Equatable {
+    public final class MultiPoint: GeoJsonMultiPoint, Equatable {
         public let type: GeoJsonObjectType = .multiPoint
         public var geoJsonCoordinates: [Any] { return points.map { $0.geoJsonCoordinates } }
         

--- a/GeospatialKit/API/GeoJson/Object/MultiPolygon.swift
+++ b/GeospatialKit/API/GeoJson/Object/MultiPolygon.swift
@@ -12,7 +12,7 @@ extension GeoJson {
         return MultiPolygon(logger: logger, geodesicCalculator: geodesicCalculator, polygons: polygons)
     }
     
-    public class MultiPolygon: GeoJsonMultiPolygon, Equatable {
+    public final class MultiPolygon: GeoJsonMultiPolygon, Equatable {
         public let type: GeoJsonObjectType = .multiPolygon
         public var geoJsonCoordinates: [Any] { return polygons.map { $0.geoJsonCoordinates } }
         

--- a/GeospatialKit/API/GeoJson/Object/Point.swift
+++ b/GeospatialKit/API/GeoJson/Object/Point.swift
@@ -40,7 +40,9 @@ extension GeoJson {
         // TODO: Need a better way to know when to include and exclude altitude in calculations. Currently excluded.
         public let altitude: Double?
         
-        public let boundingBox: GeoJsonBoundingBox
+        public var boundingBox: GeoJsonBoundingBox {
+            return BoundingBox(boundingCoordinates: (minLongitude: longitude, minLatitude: latitude, maxLongitude: longitude, maxLatitude: latitude))
+        }
         
         public let hashValue: Int
         
@@ -58,8 +60,6 @@ extension GeoJson {
             self.latitude = latitude
             self.altitude = altitude
             
-            let boundingCoordinates = (minLongitude: longitude, minLatitude: latitude, maxLongitude: longitude, maxLatitude: latitude)
-            boundingBox = BoundingBox(boundingCoordinates: boundingCoordinates)
             hashValue = [longitude.hashValue, latitude.hashValue, altitude?.hashValue ?? 0].reduce(5381) { ($0 << 5) &+ $0 &+ Int($1) }
         }
         

--- a/GeospatialKit/API/GeoJson/Object/Point.swift
+++ b/GeospatialKit/API/GeoJson/Object/Point.swift
@@ -24,7 +24,7 @@ extension GeoJson {
         return Point(logger: logger, geodesicCalculator: geodesicCalculator, longitude: longitude, latitude: latitude, altitude: altitude)
     }
     
-    public class Point: GeoJsonPoint, Hashable {
+    public final class Point: GeoJsonPoint, Hashable {
         public let type: GeoJsonObjectType = .point
         public var geoJsonCoordinates: [Any] { return altitude != nil ? [longitude, latitude, altitude!] : [longitude, latitude] }
         

--- a/GeospatialKit/API/GeoJson/Object/Polygon.swift
+++ b/GeospatialKit/API/GeoJson/Object/Polygon.swift
@@ -13,7 +13,7 @@ extension GeoJson {
         return Polygon(logger: logger, geodesicCalculator: geodesicCalculator, linearRings: linearRings)
     }
     
-    public class Polygon: GeoJsonPolygon, Equatable {
+    public final class Polygon: GeoJsonPolygon, Equatable {
         public let type: GeoJsonObjectType = .polygon
         public var geoJsonCoordinates: [Any] { return linearRings.map { $0.geoJsonCoordinates } }
         

--- a/GeospatialKit/API/Geohash/GeohashBox.swift
+++ b/GeospatialKit/API/Geohash/GeohashBox.swift
@@ -8,7 +8,7 @@ public enum GeohashCompassPoint {
     case north, south, east, west
 }
 
-public class GeohashBox: BoundingBox, GeoJsonGeohashBox {
+public final class GeohashBox: BoundingBox, GeoJsonGeohashBox {
     private let geohashCoder: GeohashCoderProtocol
     
     public let geohash: String

--- a/GeospatialKitTests/Data/MockData.swift
+++ b/GeospatialKitTests/Data/MockData.swift
@@ -1,7 +1,7 @@
 @testable import GeospatialKit
 
 // swiftlint:disable force_cast force_try
-class MockData {
+final class MockData {
     static let geoJson = GeoJson(logger: MockLogger(), geodesicCalculator: GeodesicCalculator(logger: MockLogger()))
     
     static let geoJsonTestData: [GeoJsonDictionary] = { return read(fileName: "GeoJsonTestData")["geoJsonObjects"] as! [GeoJsonDictionary] }()

--- a/GeospatialKitTests/Mock/API/GeoJson/Box/MockGeoJsonGeohashBox.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/Box/MockGeoJsonGeohashBox.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeoJsonGeohashBox: MockGeoJsonBoundingBox, GeoJsonGeohashBox {
+final class MockGeoJsonGeohashBox: MockGeoJsonBoundingBox, GeoJsonGeohashBox {
     private(set) var geohashCallCount = 0
     private(set) var geohashNeighborCallCount = 0
     

--- a/GeospatialKitTests/Mock/API/GeoJson/MockGeoJson.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/MockGeoJson.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeoJson: GeoJsonProtocol {
+final class MockGeoJson: GeoJsonProtocol {
     private(set) var parseCallCount = 0
     private(set) var featureCollectionCallCount = 0
     private(set) var featureCallCount = 0

--- a/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonFeature.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonFeature.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeoJsonFeature: MockGeoJsonGeometry, GeoJsonFeature {
+final class MockGeoJsonFeature: MockGeoJsonGeometry, GeoJsonFeature {
     var geometryResult: GeoJsonGeometry? = MockGeoJsonPolygon()
     var idResult: Any?
     var idAsStringResult: String?

--- a/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonFeatureCollection.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonFeatureCollection.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeoJsonFeatureCollection: MockGeoJsonGeometry, GeoJsonFeatureCollection {
+final class MockGeoJsonFeatureCollection: MockGeoJsonGeometry, GeoJsonFeatureCollection {
     private(set) var featuresCallCount = 0
     
     var featuresResult: [GeoJsonFeature] = []

--- a/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonGeometryCollection.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonGeometryCollection.swift
@@ -1,4 +1,4 @@
 @testable import GeospatialKit
 
-class MockGeoJsonGeometryCollection: MockGeoJsonMultiCoordinatesGeometry, GeoJsonGeometryCollection {
+final class MockGeoJsonGeometryCollection: MockGeoJsonMultiCoordinatesGeometry, GeoJsonGeometryCollection {
 }

--- a/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonLineString.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonLineString.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeoJsonLineString: MockGeoJsonMultiCoordinatesGeometry, GeoJsonLineString {
+final class MockGeoJsonLineString: MockGeoJsonMultiCoordinatesGeometry, GeoJsonLineString {
     var segments: [GeoJsonLineSegment] = []
     
     private(set) var lengthCallCount = 0

--- a/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonMultiLineString.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonMultiLineString.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeoJsonMultiLineString: MockGeoJsonMultiCoordinatesGeometry, GeoJsonMultiLineString {
+final class MockGeoJsonMultiLineString: MockGeoJsonMultiCoordinatesGeometry, GeoJsonMultiLineString {
     private(set) var lineStringsCallCount = 0
     
     var lineStringsResult: [GeoJsonLineString] = []

--- a/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonMultiPoint.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonMultiPoint.swift
@@ -1,4 +1,4 @@
 @testable import GeospatialKit
 
-class MockGeoJsonMultiPoint: MockGeoJsonMultiCoordinatesGeometry, GeoJsonMultiPoint {
+final class MockGeoJsonMultiPoint: MockGeoJsonMultiCoordinatesGeometry, GeoJsonMultiPoint {
 }

--- a/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonMultiPolygon.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonMultiPolygon.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeoJsonMultiPolygon: MockGeoJsonMultiCoordinatesGeometry, GeoJsonMultiPolygon {
+final class MockGeoJsonMultiPolygon: MockGeoJsonMultiCoordinatesGeometry, GeoJsonMultiPolygon {
     private(set) var polygonsCallCount = 0
     
     var polygonsResult: [GeoJsonPolygon] = []

--- a/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonPoint.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonPoint.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeoJsonPoint: MockGeoJsonCoordinatesGeometry, GeoJsonPoint {
+final class MockGeoJsonPoint: MockGeoJsonCoordinatesGeometry, GeoJsonPoint {
     private(set) var locationCallCount: Int = 0
     private(set) var locationCoordinateCallCount: Int = 0
     private(set) var longitudeCallCount: Int = 0

--- a/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonPolygon.swift
+++ b/GeospatialKitTests/Mock/API/GeoJson/Object/MockGeoJsonPolygon.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeoJsonPolygon: MockGeoJsonMultiCoordinatesGeometry, GeoJsonPolygon {
+final class MockGeoJsonPolygon: MockGeoJsonMultiCoordinatesGeometry, GeoJsonPolygon {
     private(set) var linearRingsCallCount: Int = 0
     private(set) var areaCallCount: Int = 0
     

--- a/GeospatialKitTests/Mock/API/Geohash/MockGeohashCoder.swift
+++ b/GeospatialKitTests/Mock/API/Geohash/MockGeohashCoder.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeohashCoder: GeohashCoderProtocol {
+final class MockGeohashCoder: GeohashCoderProtocol {
     private(set) var geohashFromPointCallCount = 0
     private(set) var geohashBoxFromPointCallCount = 0
     private(set) var geohashBoxFromGeohashCallCount = 0

--- a/GeospatialKitTests/Mock/API/Image/MockImageManager.swift
+++ b/GeospatialKitTests/Mock/API/Image/MockImageManager.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockImageManager: ImageManagerProtocol {
+final class MockImageManager: ImageManagerProtocol {
     private(set) var createCallCount = 0
     private(set) var createDebugCallCount = 0
     

--- a/GeospatialKitTests/Mock/API/Map/MockMapManager.swift
+++ b/GeospatialKitTests/Mock/API/Map/MockMapManager.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockMapManager: MapManagerProtocol {
+final class MockMapManager: MapManagerProtocol {
     private(set) var overlaysCallCount = 0
     private(set) var annotationsCallCount = 0
     private(set) var annotationsDebugCallCount = 0

--- a/GeospatialKitTests/Mock/API/MockGeospatial.swift
+++ b/GeospatialKitTests/Mock/API/MockGeospatial.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeospatial: GeospatialProtocol {
+final class MockGeospatial: GeospatialProtocol {
     private(set) var parseWktCallCount = 0
     
     var parseWktResult: GeoJsonObject?

--- a/GeospatialKitTests/Mock/Common/MockGeodesicCalculator.swift
+++ b/GeospatialKitTests/Mock/Common/MockGeodesicCalculator.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockGeodesicCalculator: GeodesicCalculatorProtocol {
+final class MockGeodesicCalculator: GeodesicCalculatorProtocol {
     private(set) var lineLengthCallCount = 0
     private(set) var polygonAreaCallCount = 0
     private(set) var distanceToPointCallCount = 0

--- a/GeospatialKitTests/Mock/Common/MockLogger.swift
+++ b/GeospatialKitTests/Mock/Common/MockLogger.swift
@@ -1,6 +1,6 @@
 @testable import GeospatialKit
 
-class MockLogger: LoggerProtocol {
+final class MockLogger: LoggerProtocol {
     let logger = Logger(applicationPrefix: "Logger: ", minimumLogLevelShown: .debug)
     
     var writeToLogCount: Int = 0

--- a/GeospatialKitTests/Performance/GeoJsonParsingPerformanceTests.swift
+++ b/GeospatialKitTests/Performance/GeoJsonParsingPerformanceTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+@testable import GeospatialKit
+
+class GeoJsonParsingPerformanceTest: XCTestCase {
+    
+    func testPolygonBoundingBox() {
+        let geospatial = Geospatial(configuration: ConfigurationModel(logLevel: .debug))
+        
+        let geoJsons = MockData.geoJsonTestData.flatMap { $0["geoJson"] as? GeoJsonDictionary }
+        
+        var cacheForMemoryUsageInfo = [GeoJsonObject]()
+        
+        measure {
+            for _ in 0..<50 {
+                for geoJson in geoJsons {
+                    cacheForMemoryUsageInfo.append(geospatial.geoJson.parse(geoJson: geoJson)!)
+                }
+            }
+        }
+    }
+    
+}

--- a/GeospatialKitTests/Performance/GeoJsonParsingPerformanceTests.swift
+++ b/GeospatialKitTests/Performance/GeoJsonParsingPerformanceTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import GeospatialKit
 
-class GeoJsonParsingPerformanceTest: XCTestCase {
+final class GeoJsonParsingPerformanceTest: XCTestCase {
     
     func testPolygonBoundingBox() {
         let geospatial = Geospatial(configuration: ConfigurationModel(logLevel: .debug))


### PR DESCRIPTION
## Solves Issue #1 
- Takes stored values on geoJson objects that are not needed at initialization and makes them computed properties
- Made classes 'final' where applicable
- Adds a performance test. Basic example took the average parse time from ~0.210 to ~0.105. More complicated data shows more dramatic speed improvements